### PR TITLE
Upgrade requirements dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-torch==2.1.2
-torchvision==0.16.2
-torchaudio==2.1.2
-pyttsx3==2.90
-blobfile==2.1.1
-openai==1.7.0
+torch==2.7.1
+torchvision==0.22.1
+torchaudio==2.7.1
+pyttsx3==2.98
+blobfile==3.0.0
+openai==1.84.0
 Wave==0.0.2
 PyAudio==0.2.14
-PyYAML==6.0.1
-pygame==2.5.2
-soundfile==0.12.1
-pyObjC==9.0.1
-openai-whisper @ git+https://github.com/openai/whisper.git@ba3f3cd54b0e5b8ce1ab3de13e32122d0d5f98ab
+PyYAML==6.0.2
+pygame==2.6.1
+soundfile==0.13.1
+pyObjC==11.0
+openai-whisper @ git+https://github.com/openai/whisper.git@dd985ac4b90cafeef8712f2998d62c59c3e62d22


### PR DESCRIPTION
I faced with the same problem described in this [issue](https://github.com/apeatling/ollama-voice-mac/issues/19)
And, I've discovered the requirements file has a lot of outdated dependencies. I went it over looking in [pypi.org](https://pypi.org), except for the **openai-whisper** package where I took the last commit hash from the **main** branch.

So, for now, it works well, as expected in README.